### PR TITLE
Fixing bug in truth table print code

### DIFF
--- a/include/kitty/print.hpp
+++ b/include/kitty/print.hpp
@@ -53,7 +53,7 @@ void print_binary( const TT& tt, std::ostream& os = std::cout )
   for_each_block_reversed( tt, [&tt, &os]( auto word ) {
     std::string chunk( std::min<uint64_t>( tt.num_bits(), 64 ), '0' );
     auto it = chunk.rbegin();
-    while ( word )
+    while ( word && it < chunk.rend() )
     {
       if ( word & 1 )
       {


### PR DESCRIPTION
Tuth table printing would crash if words had garbage bits in them. In other words, if a 32 bit truth table is represented by a 64 bit word, and the remaining 32 bits are not set to zero, the print loop would write beyond the end of the allocated string. This could happen (for example) if the truth table was created from a block of words with garbage bits. This is a simple fix that makes sure that printing doesn't break things.