### PR TITLE
Adding support for Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ if (HAS_FCOLOR_DIAGNOSTICS)
   add_compile_options(-fcolor-diagnostics)
 endif()
 
-add_compile_options(-W -Wall -Werror)
+if (UNIX)
+    add_compile_options(-W -Wall -Werror)
+endif()
 
 add_subdirectory(include)
 

--- a/include/kitty/bit_operations.hpp
+++ b/include/kitty/bit_operations.hpp
@@ -35,6 +35,12 @@
 #include <cstdint>
 #include <numeric>
 
+// Use Windows popcount version where appropriate
+#ifdef _MSC_VER
+#include <intrin.h>
+#define __builtin_popcount __popcnt
+#endif
+
 #include "static_truth_table.hpp"
 
 namespace kitty
@@ -240,7 +246,7 @@ int64_t find_first_one_bit( const TT& tt, int64_t start = 0 )
   {
     return -1;
   }
-  
+
   return 64 * std::distance( tt.cbegin(), it ) + find_first_bit_in_word( *it );
 }
 

--- a/vsgen.bat
+++ b/vsgen.bat
@@ -1,5 +1,0 @@
-ECHO Generating Visual Studio solution in build/ folder 
-mkdir build 2> nul
-cd build
-cmake -DKITTY_TEST=ON -G "Visual Studio 15 2017" ..
-cd ..

--- a/vsgen.bat
+++ b/vsgen.bat
@@ -1,0 +1,5 @@
+ECHO Generating Visual Studio solution in build/ folder 
+mkdir build 2> nul
+cd build
+cmake -DKITTY_TEST=ON -G "Visual Studio 15 2017" ..
+cd ..


### PR DESCRIPTION
Kitty now uses the __builtin_popcount function which is not available on Windows. This fix adds a batch file to generate a Visual Studio solution for kitty and defines a macro to use the __popcnt function which is defined on (many) Windows platforms.