### PR TITLE
is_covered_with_divisors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Next release
+------------
+
+* Properties: ``is_covered_with_divisors`` (contributed by Heinz Riener)
+  `#106 <https://github.com/msoeken/kitty/pull/106>`_
+
 v0.7 (March 13, 2020)
 ---------------------
 
@@ -13,10 +19,10 @@ v0.7 (March 13, 2020)
 * Compute simple SPP from ESOP form
   `#83 <https://github.com/msoeken/kitty/pull/83>`_
 
-* Bit operation: ``count_zeros``
+* Bit operation: ``count_zeros`` (contributed by Heinz Riener)
   `#84 <https://github.com/msoeken/kitty/pull/84>`_
 
-* Properties: ``absolute_distinguishing_power``, ``relative_distinguishing_power``
+* Properties: ``absolute_distinguishing_power``, ``relative_distinguishing_power`` (contributed by Heinz Riener)
   `#84 <https://github.com/msoeken/kitty/pull/84>`_
 
 * Properties: ``polynomial_degree``

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -19,3 +19,4 @@ properties.
    polynomial_degree
    absolute_disinguishing_power
    relative_distinguishing_power
+   is_covered_with_divisors

--- a/include/kitty/properties.hpp
+++ b/include/kitty/properties.hpp
@@ -333,4 +333,41 @@ inline uint64_t relative_distinguishing_power( const TT& tt, const TT& target_tt
   return count_ones( ~tt & ~target_tt ) * count_ones( tt & target_tt ) + count_ones( ~tt & target_tt ) * count_ones( tt & ~target_tt ); 
 }
 
+/*! \brief Return true iff each distinguishing bit pair of the target
+  function is also distinguishable by the divisor functions
+  \param target Truth table of the target functions
+  \param divisors Truth tables of the divisor functions
+*/
+template<typename TT>
+bool is_covered_with_divisors( TT const& target, std::vector<TT> const& divisors )
+{
+  /* iterate over all bit pairs of the target function */
+  for ( uint32_t j = 1u; j < target.num_bits(); ++j )
+  {
+    for ( uint32_t i = 0u; i < j; ++i )
+    {
+      /* check if the bit pair is distinguished by the target function */
+      if ( get_bit( target, i ) != get_bit( target, j ) )
+      {
+        /* check if this bit pair is also distinguished by a divisor function */
+        bool found = false;
+        for ( const auto& d : divisors )
+        {
+          if ( get_bit( d, i ) != get_bit( d, j ) )
+          {
+            found = true;
+            break;
+          }
+        }
+
+        if ( !found )
+        {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
 } // namespace kitty

--- a/include/kitty/properties.hpp
+++ b/include/kitty/properties.hpp
@@ -312,7 +312,7 @@ inline uint32_t polynomial_degree( const TT& tt )
 
 /*! \brief Returns the absolute distinguishing power of a function
   The absolute distinguishing power of a function f is the number of
-  distinguishing pair {i,j} of bits, where f(i) != f(j).
+  distinguishing bit pair {i,j} such that f(i) != f(j).
   \param tt Truth table
 */
 template<typename TT>
@@ -321,9 +321,9 @@ inline uint64_t absolute_distinguishing_power( const TT& tt )
   return count_zeros( tt ) * count_ones( tt );
 }
 
-/*! brief Returns the relative distinguishing power of a function wrt. to target function
-  Quantifies the number of distinguishing pairs in the target function
-  that can be distinguished by the function.
+/*! \brief Returns the relative distinguishing power of a function wrt. to a target function
+  Quantifies the number of distinguishing bit pairs in the target function
+  that can be distinguished by another function.
   \param tt Truth table of function
   \param target_tt Truth table of target function
 */


### PR DESCRIPTION
This PR provides a new function ``is_covered_with_divisors``, which allows checking if a target function can be resynthesized by a set of divisor functions.