### PR TITLE
create_from_expression

### DIFF
--- a/include/kitty/affine.hpp
+++ b/include/kitty/affine.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/algorithm.hpp
+++ b/include/kitty/algorithm.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/bit_operations.hpp
+++ b/include/kitty/bit_operations.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/cnf.hpp
+++ b/include/kitty/cnf.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/constructors.hpp
+++ b/include/kitty/constructors.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/constructors.hpp
+++ b/include/kitty/constructors.hpp
@@ -972,20 +972,19 @@ inline void create_characteristic( TT& tt, const TTFrom& from )
 
 /*! \brief Creates truth table from textual expression
 
-  An expression `E` is a constant `0` or `1`, or a variable `a`, `b`, ..., `p`,
-  the negation of an expression `!E`, the conjunction of multiple expressions
-  `(E...E)`, the disjunction of multiple expressions `{E...E}`, the exclusive
-  OR of multiple expressions `[E...E]`, or the majority of three expressions
-  `<EEE>`.  Examples are `[(ab)(!ac)]` to describe if-then-else, or `!{!a!b}`
-  to describe the application of De Morgan's law to `(ab)`.  The size of the
-  truth table must fit the largest variable in the expression, e.g., if `c` is
-  the largest variable, then the truth table have at least three variables.
+  An expression `E` is a constant `0` or `1`, or a truth table `a`,
+  `b`, ..., `p` from the vector `input_tts`, the negation of an
+  expression `!E`, the conjunction of multiple expressions `(E...E)`,
+  the disjunction of multiple expressions `{E...E}`, the exclusive OR
+  of multiple expressions `[E...E]`, or the majority of three
+  expressions `<EEE>`.
 
   \param tt Truth table
   \param from Expression as string
+  \param input_tts Input truth tables assigned to a, b, ...
 */
 template<typename TT, typename = std::enable_if_t<is_complete_truth_table<TT>::value>>
-bool create_from_expression( TT& tt, const std::string& expression )
+bool create_from_expression( TT& tt, const std::string& expression, std::vector<TT> const& input_tts )
 {
   enum stack_symbols
   {
@@ -1016,8 +1015,8 @@ bool create_from_expression( TT& tt, const std::string& expression )
     default:
       if ( c >= 'a' && c <= 'p' )
       {
-        auto var = tt.construct();
-        create_nth_var( var, c - 'a' );
+        assert( input_tts.size() > uint64_t( c - 'a' ) );
+        auto var = input_tts[c - 'a'];
         push_tt( var );
       }
       else
@@ -1142,6 +1141,33 @@ bool create_from_expression( TT& tt, const std::string& expression )
 
   tt = truth_tables.top();
   return true;
+}
+
+/*! \brief Creates truth table from textual expression
+
+  An expression `E` is a constant `0` or `1`, or a variable `a`, `b`, ..., `p`,
+  the negation of an expression `!E`, the conjunction of multiple expressions
+  `(E...E)`, the disjunction of multiple expressions `{E...E}`, the exclusive
+  OR of multiple expressions `[E...E]`, or the majority of three expressions
+  `<EEE>`.  Examples are `[(ab)(!ac)]` to describe if-then-else, or `!{!a!b}`
+  to describe the application of De Morgan's law to `(ab)`.  The size of the
+  truth table must fit the largest variable in the expression, e.g., if `c` is
+  the largest variable, then the truth table have at least three variables.
+
+  \param tt Truth table
+  \param from Expression as string
+*/
+template<typename TT, typename = std::enable_if_t<is_complete_truth_table<TT>::value>>
+bool create_from_expression( TT& tt, const std::string& expression )
+{
+  std::vector<TT> inputs_tts( tt.num_vars() );
+  for ( uint8_t i = 0u; i < tt.num_vars(); ++i )
+  {
+    auto var = tt.construct();
+    create_nth_var( var, i );
+    inputs_tts[i] = var;
+  }
+  return create_from_expression( tt, expression, inputs_tts );
 }
 
 /*! \brief Creates function where on-set corresponds to prime numbers

--- a/include/kitty/cube.hpp
+++ b/include/kitty/cube.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/decomposition.hpp
+++ b/include/kitty/decomposition.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/detail/constants.hpp
+++ b/include/kitty/detail/constants.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/detail/linear_constants.hpp
+++ b/include/kitty/detail/linear_constants.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/detail/mscfix.hpp
+++ b/include/kitty/detail/mscfix.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/detail/shift.hpp
+++ b/include/kitty/detail/shift.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/detail/utils.hpp
+++ b/include/kitty/detail/utils.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/dynamic_truth_table.hpp
+++ b/include/kitty/dynamic_truth_table.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/enumeration.hpp
+++ b/include/kitty/enumeration.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/esop.hpp
+++ b/include/kitty/esop.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/hash.hpp
+++ b/include/kitty/hash.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/implicant.hpp
+++ b/include/kitty/implicant.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/isop.hpp
+++ b/include/kitty/isop.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/kitty.hpp
+++ b/include/kitty/kitty.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/npn.hpp
+++ b/include/kitty/npn.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/operations.hpp
+++ b/include/kitty/operations.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/operators.hpp
+++ b/include/kitty/operators.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/partial_truth_table.hpp
+++ b/include/kitty/partial_truth_table.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/permutation.hpp
+++ b/include/kitty/permutation.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/print.hpp
+++ b/include/kitty/print.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/properties.hpp
+++ b/include/kitty/properties.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/spectral.hpp
+++ b/include/kitty/spectral.hpp
@@ -1,6 +1,6 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
- * Copyright (C) 2017-2020  University of Victoria
+ * Copyright (C) 2017-2021  EPFL
+ * Copyright (C) 2017-2021  University of Victoria
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/spp.hpp
+++ b/include/kitty/spp.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/static_truth_table.hpp
+++ b/include/kitty/static_truth_table.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/include/kitty/traits.hpp
+++ b/include/kitty/traits.hpp
@@ -1,5 +1,5 @@
 /* kitty: C++ truth table library
- * Copyright (C) 2017-2020  EPFL
+ * Copyright (C) 2017-2021  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation


### PR DESCRIPTION
This PR implements a variation of `create_from_expresion` that takes an additional vector of input truth tables as a parameter. The truth tables are assigned to the variables `a`, `b`, etc., such that one can create truth tables using `create_from_expression` from other existing truth tables.