### PR TITLE
Relevance property for mig_resub

### DIFF
--- a/include/kitty/properties.hpp
+++ b/include/kitty/properties.hpp
@@ -371,4 +371,17 @@ bool is_covered_with_divisors( TT const& target, std::vector<TT> const& divisors
   return true;
 }
 
+/*! \brief Relevance */
+inline bool relevance( const dynamic_truth_table& tt0, const dynamic_truth_table& tt1, const dynamic_truth_table& tt2, const dynamic_truth_table& tt )
+{
+  return is_const0( ( ( tt0 ^ tt ) & ( tt1 ^ tt2 ) ) );
+}
+
+/*! \brief Relevance */
+template<uint32_t NumVars>
+inline bool relevance( const static_truth_table<NumVars>& tt0, const static_truth_table<NumVars>& tt1, const static_truth_table<NumVars>& tt2, const static_truth_table<NumVars>& tt )
+{
+  return is_const0( ( ( tt0 ^ tt ) & ( tt1 ^ tt2 ) ) );
+}
+
 } // namespace kitty


### PR DESCRIPTION
This method was placed in `mockturtle/mig_resub` under `namespace kitty`. I think it makes more sense to move them directly into `kitty`.