### PR TITLE
Ternary predicate

### DIFF
--- a/docs/algorithm.rst
+++ b/docs/algorithm.rst
@@ -8,6 +8,7 @@ The header ``<kitty/algorithm.hpp>`` implements several generic algorithms on tr
    binary_operation
    ternary_operation
    binary_predicate
+   ternary_predicate
    assign_operation
    for_each_block
    for_each_block_reversed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Next release
 * Algorithm: ``ternary_predicate`` (contributed by Siang-Yun Lee)
   `#120 <https://github.com/msoeken/kitty/pull/120>`_
 
+* Operation: ``intersection_is_empty`` (contributed by Siang-Yun Lee)
+  `#120 <https://github.com/msoeken/kitty/pull/120>`_
+
 v0.7 (March 13, 2020)
 ---------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ Next release
 * Properties: ``is_covered_with_divisors`` (contributed by Heinz Riener)
   `#106 <https://github.com/msoeken/kitty/pull/106>`_
 
+* Algorithm: ``ternary_predicate`` (contributed by Siang-Yun Lee)
+  `#120 <https://github.com/msoeken/kitty/pull/120>`_
+
 v0.7 (March 13, 2020)
 ---------------------
 

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -12,6 +12,7 @@ Predicates
    has_var
    is_const0
    implies
+   intersection_is_empty
 
 Combination and manipulation
 ----------------------------

--- a/include/kitty/algorithm.hpp
+++ b/include/kitty/algorithm.hpp
@@ -267,7 +267,7 @@ bool binary_predicate( const partial_truth_table& first, const partial_truth_tab
 template<typename TT, typename Fn>
 bool ternary_predicate( const TT& first, const TT& second, const TT& third, Fn&& op )
 {
-  assert( first.num_blocks() == second.num_blocks() );
+  assert( first.num_blocks() == second.num_blocks() && first.num_blocks() == third.num_blocks() );
 
   for ( auto i = 0u; i < first.num_blocks(); ++i )
   {

--- a/include/kitty/algorithm.hpp
+++ b/include/kitty/algorithm.hpp
@@ -251,6 +251,42 @@ bool binary_predicate( const partial_truth_table& first, const partial_truth_tab
 }
 /*! \endcond */
 
+/*! \brief Computes a predicate based on three truth tables
+
+  The dimensions of `first`, `second` and `third` must match.  This is ensured
+  at compile-time for static truth tables, but at run-time for dynamic
+  truth tables.
+
+  \param first First truth table
+  \param second Second truth table
+  \param third Third truth table
+  \param op Ternary operation that takes as input three words (`uint64_t`) and returns a Boolean
+
+  \return true or false based on the predicate
+ */
+template<typename TT, typename Fn>
+bool ternary_predicate( const TT& first, const TT& second, const TT& third, Fn&& op )
+{
+  assert( first.num_blocks() == second.num_blocks() );
+
+  for ( auto i = 0u; i < first.num_blocks(); ++i )
+  {
+    if ( !op( first._bits[i], second._bits[i], third._bits[i] ) )
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+/*! \cond PRIVATE */
+template<uint32_t NumVars, typename Fn>
+bool ternary_predicate( const static_truth_table<NumVars, true>& first, const static_truth_table<NumVars, true>& second, const static_truth_table<NumVars, true>& third, Fn&& op )
+{
+  return op( first._bits, second._bits, third._bits );
+}
+/*! \endcond */
+
 /*! \brief Assign computed values to bits
 
   The functor `op` computes bits which are assigned to the bits of the

--- a/include/kitty/operations.hpp
+++ b/include/kitty/operations.hpp
@@ -234,11 +234,20 @@ inline bool is_const0( const static_truth_table<NumVars, true>& tt )
 
   \param first First truth table
   \param second Second truth table
+  \param polarity1 Polarity of the first truth table
+  \param polarity2 Polarity of the second truth table
 */
-template<typename TT>
-inline bool intersection_is_empty( const TT& first, const TT& second )
+template<typename TT, bool polarity1 = true, bool polarity2 = true>
+bool intersection_is_empty( const TT& first, const TT& second )
 {
-  return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & b ) == 0u; } );
+  if constexpr ( polarity1 && polarity2 )
+    return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & b ) == 0u; } );
+  else if constexpr ( !polarity1 && polarity2 )
+    return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( ~a & b ) == 0u; } );
+  else if constexpr ( polarity1 && !polarity2 )
+    return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & ~b ) == 0u; } );
+  else // !polarity1 && !polarity2
+    return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( ~a & ~b ) == 0u; } );
 }
 
 /*! \brief Checks whether the intersection of three truth tables is empty
@@ -246,11 +255,29 @@ inline bool intersection_is_empty( const TT& first, const TT& second )
   \param first First truth table
   \param second Second truth table
   \param third Third truth table
+  \param polarity1 Polarity of the first truth table
+  \param polarity2 Polarity of the second truth table
+  \param polarity3 Polarity of the first truth table
 */
-template<typename TT>
-inline bool intersection_is_empty( const TT& first, const TT& second, const TT& third )
+template<typename TT, bool polarity1 = true, bool polarity2 = true, bool polarity3 = true>
+bool intersection_is_empty( const TT& first, const TT& second, const TT& third )
 {
-  return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & b & c ) == 0u; } );
+  if constexpr ( polarity1 && polarity2 && polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & b & c ) == 0u; } );
+  else if constexpr ( !polarity1 && polarity2 && polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( ~a & b & c ) == 0u; } );
+  else if constexpr ( polarity1 && !polarity2 && polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & ~b & c ) == 0u; } );
+  else if constexpr ( polarity1 && polarity2 && !polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & b & ~c ) == 0u; } );
+  else if constexpr ( !polarity1 && !polarity2 && polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( ~a & ~b & c ) == 0u; } );
+  else if constexpr ( polarity1 && !polarity2 && !polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & ~b & ~c ) == 0u; } );
+  else if constexpr ( !polarity1 && polarity2 && !polarity3 )
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( ~a & b & ~c ) == 0u; } );
+  else // !polarity1 && !polarity2 && !polarity3
+    return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( ~a & ~b & ~c ) == 0u; } );
 }
 
 /*! \brief Checks whether truth table depends on given variable index

--- a/include/kitty/operations.hpp
+++ b/include/kitty/operations.hpp
@@ -241,6 +241,18 @@ inline bool intersection_is_empty( const TT& first, const TT& second )
   return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & b ) == 0u; } );
 }
 
+/*! \brief Checks whether the intersection of three truth tables is empty
+
+  \param first First truth table
+  \param second Second truth table
+  \param third Third truth table
+*/
+template<typename TT>
+inline bool intersection_is_empty( const TT& first, const TT& second, const TT& third )
+{
+  return ternary_predicate( first, second, third, []( uint64_t a, uint64_t b, uint64_t c ){ return ( a & b & c ) == 0u; } );
+}
+
 /*! \brief Checks whether truth table depends on given variable index
 
   \param tt Truth table

--- a/include/kitty/operations.hpp
+++ b/include/kitty/operations.hpp
@@ -187,7 +187,7 @@ inline bool equal( const partial_truth_table& first, const partial_truth_table& 
 template<typename TT>
 inline bool implies( const TT& first, const TT& second )
 {
-  return is_const0( binary_operation( first, second, []( auto a, auto b ) { return ~( ~a | b ); } ) );
+  return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & ~b ) == 0u; } );
 }
 
 /*! \brief Checks whether a truth table is lexicographically smaller than another
@@ -229,6 +229,17 @@ inline bool is_const0( const static_truth_table<NumVars, true>& tt )
   return tt._bits == 0;
 }
 /*! \endcond */
+
+/*! \brief Checks whether the intersection of two truth tables is empty
+
+  \param first First truth table
+  \param second Second truth table
+*/
+template<typename TT>
+inline bool intersection_is_empty( const TT& first, const TT& second )
+{
+  return binary_predicate( first, second, []( uint64_t a, uint64_t b ){ return ( a & b ) == 0u; } );
+}
 
 /*! \brief Checks whether truth table depends on given variable index
 

--- a/test/operations.cpp
+++ b/test/operations.cpp
@@ -818,3 +818,11 @@ TEST_F( OperationsTest, shift_with_mask )
   EXPECT_EQ( shift_with_mask( from_hex<6>( "e8e8e8e8e8e8e8e8" ), 0b111000 ), from_hex<6>( "ffffff00ff000000" ) );
   EXPECT_EQ( shift_with_mask( from_hex<6>( "7778777877787778" ), 0b101101 ), from_hex<6>( "5f5f5f5f5fa05fa0" ) );
 }
+
+TEST_F( OperationsTest, intersection_is_empty )
+{
+  EXPECT_TRUE( intersection_is_empty( from_hex<3>( "a2" ), from_hex<3>( "5c" ) ) );
+  EXPECT_TRUE( intersection_is_empty( from_hex( 3, "a2" ), from_hex( 3, "5c" ) ) );
+  EXPECT_TRUE( !intersection_is_empty( from_hex<3>( "f0" ), from_hex<3>( "5c" ) ) );
+  EXPECT_TRUE( !intersection_is_empty( from_hex( 3, "f0" ), from_hex( 3, "5c" ) ) );
+}

--- a/test/operations.cpp
+++ b/test/operations.cpp
@@ -825,4 +825,9 @@ TEST_F( OperationsTest, intersection_is_empty )
   EXPECT_TRUE( intersection_is_empty( from_hex( 3, "a2" ), from_hex( 3, "5c" ) ) );
   EXPECT_TRUE( !intersection_is_empty( from_hex<3>( "f0" ), from_hex<3>( "5c" ) ) );
   EXPECT_TRUE( !intersection_is_empty( from_hex( 3, "f0" ), from_hex( 3, "5c" ) ) );
+
+  EXPECT_TRUE( intersection_is_empty( from_hex<3>( "a2" ), from_hex<3>( "5c" ), from_hex<3>( "01" ) ) );
+  EXPECT_TRUE( intersection_is_empty( from_hex( 3, "a2" ), from_hex( 3, "5c" ), from_hex( 3, "01" ) ) );
+  EXPECT_TRUE( !intersection_is_empty( from_hex<3>( "f0" ), from_hex<3>( "cc" ), from_hex<3>( "83" ) ) );
+  EXPECT_TRUE( !intersection_is_empty( from_hex( 3, "f0" ), from_hex( 3, "cc" ), from_hex( 3, "83" ) ) );
 }

--- a/test/operations.cpp
+++ b/test/operations.cpp
@@ -830,4 +830,7 @@ TEST_F( OperationsTest, intersection_is_empty )
   EXPECT_TRUE( intersection_is_empty( from_hex( 3, "a2" ), from_hex( 3, "5c" ), from_hex( 3, "01" ) ) );
   EXPECT_TRUE( !intersection_is_empty( from_hex<3>( "f0" ), from_hex<3>( "cc" ), from_hex<3>( "83" ) ) );
   EXPECT_TRUE( !intersection_is_empty( from_hex( 3, "f0" ), from_hex( 3, "cc" ), from_hex( 3, "83" ) ) );
+
+  bool res = intersection_is_empty<static_truth_table<3>, true, false>( from_hex<3>( "a2" ), from_hex<3>( "ff" ) );
+  EXPECT_TRUE( res );
 }


### PR DESCRIPTION
- Extend `binary_predicate` to work with ternary operations
- Add operation `intersection_is_empty`
- Modify the implementation of `implies` using `binary_predicate` (should be faster)